### PR TITLE
Handle undefined values.

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -312,6 +312,7 @@ function PrettyStream(opts){
     Object.keys(rec).forEach(function(key) {
       if (skip.indexOf(key) === -1){
         var value = rec[key];
+        if (typeof value === 'undefined') value = '';
         var stringified = false;
         if (typeof value !== 'string') {
           value = JSON.stringify(value, null, 2);

--- a/test/prettystream.test.js
+++ b/test/prettystream.test.js
@@ -50,6 +50,15 @@ var extraFieldRecord = {
   msg:"My message",
   time:"2012-02-08T22:56:52.856Z",
   v:0};
+var undefinedFields = {
+  name: "myservice",
+  pid: 123,
+  hostname:"example.com",
+  level:30,
+  msg:"My message",
+  time:"2012-02-08T22:56:52.856Z",
+  defined: undefined,
+  v:0};
 var simpleReqRecord = {"name":"amon-master","hostname":"9724a190-27b6-4fd8-830b-a574f839c67d","pid":12859,"route":"HeadAgentProbes","req_id":"cce79d15-ffc2-487c-a4e4-e940bdaac31e","level":20,"contentMD5":"11FxOYiYfpMxmANj4kGJzg==","msg":"headAgentProbes respond","time":"2012-08-08T10:25:47.636Z","v":0};
 var detailedReqResRecord = {"name":"amon-master","hostname":"9724a190-27b6-4fd8-830b-a574f839c67d","pid":12859,"audit":true,"level":30,"remoteAddress":"10.2.207.2","remotePort":50394,"req_id":"cce79d15-ffc2-487c-a4e4-e940bdaac31e","req":{"method":"HEAD","url":"/agentprobes?agent=ccf92af9-0b24-46b6-ab60-65095fdd3037","headers":{"accept":"application/json","content-type":"application/json","host":"10.2.207.16","connection":"keep-alive"},"httpVersion":"1.1","trailers":{},"version":"*"},"res":{"statusCode":200,"headers":{"content-md5":"11FxOYiYfpMxmANj4kGJzg==","access-control-allow-origin":"*","access-control-allow-headers":"Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version","access-control-allow-methods":"HEAD","access-control-expose-headers":"X-Api-Version, X-Request-Id, X-Response-Time","connection":"Keep-Alive","date":"Wed, 08 Aug 2012 10:25:47 GMT","server":"Amon Master/1.0.0","x-request-id":"cce79d15-ffc2-487c-a4e4-e940bdaac31e","x-response-time":3},"trailer":false},"route":{"name":"HeadAgentProbes","version":false},"latency":3,"secure":false,"_audit":true,"msg":"HeadAgentProbes handled: 200","time":"2012-08-08T10:25:47.637Z","v":0};
 
@@ -64,6 +73,12 @@ describe('A PrettyStream', function(){
     var prettyStream = new PrettyStream({useColor: false});
     var result = prettyStream.formatRecord(extraFieldRecord);
     result.should.equal('[2012-02-08T22:56:52.856Z]  INFO: myservice/123 on example.com: My message (extra=field)\n');
+  });
+
+  it('should print undefined fields as empty strings', function(){
+    var prettyStream = new PrettyStream({useColor: false});
+    var result = prettyStream.formatRecord(undefinedFields);
+    result.should.equal('[2012-02-08T22:56:52.856Z]  INFO: myservice/123 on example.com: My message (defined="")\n');
   });
 
   it('should pretty print colored log statments', function(){


### PR DESCRIPTION
Convert undefined values into empty strings.
Fixes

```
TypeError: Cannot call method 'indexOf' of undefined
at bunyan-prettystream/lib/prettystream.js:320:19
```

error.

Test included.
