### PR TITLE
Added `none` mode, for dropping log prefix info.

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -22,7 +22,7 @@ var colors = {
 };
 
 var defaultOptions = {
-  mode: 'long', //short, long, dev
+  mode: 'long', //short, long, dev, none
   useColor: true
 };
 
@@ -378,17 +378,6 @@ function PrettyStream(opts){
       (details.length ? details.join('\n    --\n') + '\n' : ''), 'grey');
 
 
-    if (config.mode === 'long'){
-      return format('[%s] %s: %s on %s%s: %s%s\n%s',
-        time,
-        level,
-        name,
-        host,
-        src,
-        msg,
-        extras,
-        details);
-    }
     if (config.mode === 'short'){
       return format('[%s] %s %s: %s%s\n%s',
         time,
@@ -398,11 +387,28 @@ function PrettyStream(opts){
         extras,
         details);
     }
-    if (config.mode === 'dev'){
+    else if (config.mode === 'dev'){
       return format('%s %s %s %s: %s%s\n%s',
         time,
         level,
         name,
+        src,
+        msg,
+        extras,
+        details);
+    }
+    else if (config.mode === 'none'){
+      return format('%s%s\n%s',
+        msg,
+        extras,
+        details);
+    }
+    else { //if (config.mode === 'long'){
+      return format('[%s] %s: %s on %s%s: %s%s\n%s',
+        time,
+        level,
+        name,
+        host,
         src,
         msg,
         extras,


### PR DESCRIPTION
I find it useful to allow developers to opt into removing all of the logging `chrome` that is the often large prefix present, even in `short` mode `(date + level + name) === > 20 chars` on an 80 char terminal.
