### PR TITLE
Add local time zone & time formatting configuration

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -5,6 +5,9 @@ var util = require('util');
 var format = util.format;
 var http = require('http');
 
+var moment = require('moment');
+moment().format();
+
 var colors = {
   'bold' : [1, 22],
   'italic' : [3, 23],
@@ -23,7 +26,9 @@ var colors = {
 
 var defaultOptions = {
   mode: 'long', //short, long, dev
-  useColor: true
+  useColor: true,
+  UTC: true,
+  timeFormat: moment.defaultFormat
 };
 
 var levelFromName = {
@@ -101,9 +106,12 @@ function PrettyStream(opts){
   }
 
   function extractTime(rec){
-    var time = (typeof rec.time === 'object') ? rec.time.toISOString() : rec.time;
-
-    if ((config.mode === 'short' || config.mode === 'dev') && time[10] == 'T') {
+    var time = (config.UTC) ? moment(time).utc() : moment(time);
+    
+    if (time.isValid()) time = time.format(config.timeFormat);
+    else time = (typeof rec.time === 'object') ? rec.time.toISOString() : rec.time;
+    
+    if ((config.mode === 'short' || config.mode === 'dev') && time[10] == 'T' && config.timeFormat == moment.defaultFormat) {
       return stylize(time.substr(11));
     }
     return stylize(time);

--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -111,7 +111,7 @@ function PrettyStream(opts){
     if (time.isValid()) time = time.format(config.timeFormat);
     else time = (typeof rec.time === 'object') ? rec.time.toISOString() : rec.time;
     
-    if ((config.mode === 'short' || config.mode === 'dev') && time[10] == 'T' && config.timeFormat == moment.defaultFormat) {
+    if ((config.mode === 'short' || config.mode === 'dev') && time[10] == 'T' && config.timeFormat == defaultOptions.timeFormat) {
       return stylize(time.substr(11));
     }
     return stylize(time);

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
     "type": "git",
     "url": "git://github.com/mrrama/node-bunyan-prettystream.git"
   },
-  "engines": ["node >=0.8.0"],
+  "engines": { "node": ">=0.8.0" },
   "keywords": ["log", "logging", "console", "bunyan", "development", "stream"],
+
+  "dependencies": {
+    "moment": "~2.8"
+  },
 
   "devDependencies": {
     "mocha": "1.11.0",
-    "blanket" : "1.1.5",
-    "mocha-lcov-reporter" : "0.0.1",
+    "blanket": "1.1.5",
+    "mocha-lcov-reporter": "0.0.1",
     "coveralls": "2.0.13",
     "travis-cov": "0.2.4",
     "should": "1.2.2"

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,30 @@ This library is only really meant for development and should not be used on prod
   });
   ```
 
+# Options
+
+  ```javascript
+  var prettyStdOut = new PrettyStream({ 
+      mode: 'long', //short, long, dev
+      useColor: true,
+      UTC: true,
+      timeFormat: moment.defaultFormat // "2014-11-10T23:35:25+00:00" (ISO 8601)
+  });
+  ```
+  
+`UTC` defaults to `true`, while setting `false` will use the machine's local time zone.
+
+`timeFormat` uses [moment.js conventions](http://momentjs.com/docs/#/displaying/format/) and defaults to ISO 8601 format.
+
+Custom time formatting example:
+
+  ```javascript
+  var prettyStdOut = new PrettyStream({ 
+      UTC: false,
+      timeFormat: 'YYYY-MM-DD HH:mm:ssZZ' // "2014-11-10 14:47:32-0800"
+  });
+  ```
+
 # Tests
 
 Running unit tests requires `mocha` installed.


### PR DESCRIPTION
Use moment.js to add option to display timestamps in local time, but default to UTC. Also add the option to customize the time formatting, using [moment.js conventions](http://momentjs.com/docs/#/displaying/format/).

Adds moment.js dependency.

Adds options:

`config.UTC: TRUE`
`config.timeFormat: moment.defaultFormat`
