### PR TITLE
Do not log object properties that are functions

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -312,11 +312,17 @@ function PrettyStream(opts){
     Object.keys(rec).forEach(function(key) {
       if (skip.indexOf(key) === -1){
         var value = rec[key];
-        if (typeof value === 'undefined') value = '';
         var stringified = false;
+        if (typeof value === 'function') {
+          return;
+        }
         if (typeof value !== 'string') {
           value = JSON.stringify(value, null, 2);
           stringified = true;
+        }
+        if (typeof value === 'undefined') {
+            value = '';
+            stringified = false;
         }
         if (value.indexOf('\n') !== -1 || value.length > 50) {
           details.push(key + ': ' + value);


### PR DESCRIPTION
Do not log object properties that are functions and try `JSON.stringify` before checking for undefined.

Standard Bunyan pretty-printing (with the CLI tool) does not include properties that are functions in its output. Also, `JSON.stringify` will return undefined if it cannot figure out what to do with its argument, so calling stringify before checking if a value is undefined ensures that we always handle undefined values properly.

As an example (although this is handled by explicitly checking for `typeof function`):

``` javascript
var fn = function () { return 'foo'; };
var value = JSON.stringify(fn, null, 2);
value.indexOf(value); // this throws an exception because value is undefined
```

This reordering of if statements guarantees we don't call `indexOf` on something undefined.
