### PR TITLE
Handle circular structures using json-stringify-safe.

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -4,6 +4,7 @@ var Stream = require('stream').Stream;
 var util = require('util');
 var format = util.format;
 var http = require('http');
+var stringify = require('json-stringify-safe');
 
 var colors = {
   'bold' : [1, 22],
@@ -170,7 +171,7 @@ function PrettyStream(opts){
       );
 
       if (req.body) {
-        str += '\n\n' + (typeof (req.body) === 'object' ? JSON.stringify(req.body, null, 2) : req.body);
+        str += '\n\n' + (typeof (req.body) === 'object' ? stringify(req.body, null, 2) : req.body);
       }
       if (req.trailers && Object.keys(req.trailers) > 0) {
         str += '\n' + Object.keys(req.trailers).map(function (t) {
@@ -211,7 +212,7 @@ function PrettyStream(opts){
     }
 
     if (res.body) {
-      s += '\n\n' + (typeof (res.body) === 'object' ? JSON.stringify(res.body, null, 2) : res.body);
+      s += '\n\n' + (typeof (res.body) === 'object' ? stringify(res.body, null, 2) : res.body);
     }
     if (res.trailer) {
       s += '\n' + res.trailer;
@@ -270,7 +271,7 @@ function PrettyStream(opts){
 
       if (client_req.body) {
         s += '\n\n' + (typeof (client_req.body) === 'object' ?
-                       JSON.stringify(client_req.body, null, 2) :
+                       stringify(client_req.body, null, 2) :
                        client_req.body);
       }
 
@@ -315,13 +316,13 @@ function PrettyStream(opts){
         if (typeof value === 'undefined') value = '';
         var stringified = false;
         if (typeof value !== 'string') {
-          value = JSON.stringify(value, null, 2);
+          value = stringify(value, null, 2);
           stringified = true;
         }
         if (value.indexOf('\n') !== -1 || value.length > 50) {
           details.push(key + ': ' + value);
         } else if (!stringified && (value.indexOf(' ') != -1 ||  value.length === 0)){
-          extras[key] = JSON.stringify(value);
+          extras[key] = stringify(value);
         } else {
           extras[key] = value;
         }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "engines": ["node >=0.8.0"],
   "keywords": ["log", "logging", "console", "bunyan", "development", "stream"],
 
+  "dependencies": {
+    "json-stringify-safe": "^5.0.1"
+  },
   "devDependencies": {
     "mocha": "1.11.0",
     "blanket" : "1.1.5",

--- a/test/prettystream.test.js
+++ b/test/prettystream.test.js
@@ -133,6 +133,32 @@ describe('A PrettyStream', function(){
     prettyStream.write(simpleRecord);
     prettyStream.end();
   });
+
+  it('should work on circular structures', function() {
+    var prettyStream = new PrettyStream({useColor: false});
+    var obj = {name: "Alice", child: {name: "Bob"}};
+    //obj.child.self = obj.child;
+    var circularRecord = {
+      name: "myservice",
+      pid: 123,
+      hostname: "example.com",
+      level: 30,
+      msg: "Test",
+      time: "2012-02-08T22:56:52.856Z",
+      v: 0,
+      child: {name: "Bob"}
+    };
+    circularRecord.child.self = circularRecord.child;
+
+    var result = prettyStream.formatRecord(circularRecord);
+    var expected = [
+      '[2012-02-08T22:56:52.856Z]  INFO: myservice/123 on example.com: Test',
+      '    child: {',
+      '      "name": "Bob",',
+      '      "self": "[Circular ~]"',
+      '    }'].join('\n') + "\n";
+    result.should.equal(expected);
+  });
 });
 
 


### PR DESCRIPTION
When trying to log http.Request / Response objects from Node.js 0.12, the module fails because of circular object structures. Using the `json-stringify-safe` module prevents this.
