### PR TITLE
Try/catching around JSON.stringify() 

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -315,7 +315,11 @@ function PrettyStream(opts){
         if (typeof value === 'undefined') value = '';
         var stringified = false;
         if (typeof value !== 'string') {
-          value = JSON.stringify(value, null, 2);
+          try {
+            value = JSON.stringify(value, null, 2);
+          } catch(error) {
+            value = value.toString();
+          }
           stringified = true;
         }
         if (value.indexOf('\n') !== -1 || value.length > 50) {


### PR DESCRIPTION
Useful for not failing when a non JSON stringifiable objects are passed.
